### PR TITLE
Prevent mixed-content warnings from browsers.

### DIFF
--- a/src/main/resources/site/layout.html
+++ b/src/main/resources/site/layout.html
@@ -93,7 +93,7 @@
         </div>
       </div>
     </footer>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="/resources/scripts/libs/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="/resources/scripts/libs/swiper.min.js"></script>
     <script src="/resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/documentation.html
+++ b/src/main/resources/static-site/documentation.html
@@ -378,7 +378,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/faqs.html
+++ b/src/main/resources/static-site/faqs.html
@@ -133,7 +133,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/help-support.html
+++ b/src/main/resources/static-site/help-support.html
@@ -121,7 +121,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/home.html
+++ b/src/main/resources/static-site/home.html
@@ -255,7 +255,7 @@
       </div>
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/clipboard.min.js"></script>

--- a/src/main/resources/static-site/modules-assets.html
+++ b/src/main/resources/static-site/modules-assets.html
@@ -296,7 +296,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/modules.html
+++ b/src/main/resources/static-site/modules.html
@@ -100,7 +100,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>

--- a/src/main/resources/static-site/quick-start.html
+++ b/src/main/resources/static-site/quick-start.html
@@ -192,7 +192,7 @@
     </footer>
     <!--localhost:35729/livereload.js BORRAR EN PRODUCCION-->
     <script src="http://localhost:35729/livereload.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="resources/scripts/jquery-2.1.4.min.js"><\/script>')</script>
     <script src="resources/scripts/libs/swiper.min.js"></script>
     <script src="resources/scripts/application.js"></script>


### PR DESCRIPTION
- The Jooby site is loaded via TLS. Loading from
non TLS endpoints causes browsers to freak out
and throw mixed content warnings. Also Chrome flat
out refuses to load jQuery.